### PR TITLE
Fix 'Copy token to clipboard'-functionality

### DIFF
--- a/jwt-panel.html
+++ b/jwt-panel.html
@@ -6,9 +6,9 @@
 </head>
 <body>
 <div id="caption">Waiting for request with <b>Authorization: Bearer [token]</b></div>
-<div id="claims"></div>
 <div>
   <button id="copy_token" disabled>Copy token to clipboard</button>
 </div>
+<div id="claims"></div>
 </body>
 </html>

--- a/jwt-panel.js
+++ b/jwt-panel.js
@@ -53,6 +53,7 @@ function updateCopyButton(tok) {
   b.disabled = false;
 }
 
+// Taken from: https://stackoverflow.com/a/18455088/1823175
 function copyTextToClipboard(text) {
   //Create a textbox field where we can insert text to. 
   var copyFrom = document.createElement("textarea");

--- a/jwt-panel.js
+++ b/jwt-panel.js
@@ -1,5 +1,5 @@
 function bearer_token(h) {
-  return h && h.name == "Authorization" && h.value && h.value.startsWith("Bearer ") ? h.value.substring(7) : null;
+  return h && h.name && h.name.toLowerCase() == "authorization" && h.value && h.value.startsWith("Bearer ") ? h.value.substring(7) : null;
 }
 
 function isObject(obj) {
@@ -53,9 +53,35 @@ function updateCopyButton(tok) {
   b.disabled = false;
 }
 
+function copyTextToClipboard(text) {
+  //Create a textbox field where we can insert text to. 
+  var copyFrom = document.createElement("textarea");
+
+  //Set the text content to be the text you wished to copy.
+  copyFrom.textContent = text;
+
+  //Append the textbox field into the body as a child. 
+  //"execCommand()" only works when there exists selected text, and the text is inside 
+  //document.body (meaning the text is part of a valid rendered HTML element).
+  document.body.appendChild(copyFrom);
+
+  //Select all the text!
+  copyFrom.select();
+
+  //Execute command
+  document.execCommand('copy');
+
+  //(Optional) De-select the text using blur(). 
+  copyFrom.blur();
+
+  //Remove the textbox field from the document.body, so no other JavaScript nor 
+  //other elements can get access to this.
+  document.body.removeChild(copyFrom);
+}
+
 function copyToken() {
   var t = this.dataset.token;
-  navigator.clipboard.writeText(t);
+  copyTextToClipboard(t);
 }
 
 function onRequestFinished(request) {


### PR DESCRIPTION
Nice, quick and dirty browser extension that exactly suits my ditto needs. Unfortunately, the 'copy token to clipboard'-button seems to invoke the `navigator.clipboard.writeText`-API which (recent versions of?) Chrome doesn't seem to support. This dirty little hack bypasses it.